### PR TITLE
Make env vars names consistent

### DIFF
--- a/knexfile.js
+++ b/knexfile.js
@@ -6,7 +6,7 @@ module.exports = {
       host: process.env.TASKFLOW_POSTGRES_HOST || 'localhost',
       user: process.env.TASKFLOW_POSTGRES_USER || 'taskflow-test',
       password: process.env.TASKFLOW_POSTGRES_PASSWORD,
-      database: process.env.TASKFLOW_POSTGRES_DB || 'taskflow-test',
+      database: process.env.TASKFLOW_POSTGRES_DATABASE || 'taskflow-test',
       port: process.env.TASKFLOW_POSTGRES_PORT || 5432
     }
   }


### PR DESCRIPTION
In /lib/db/migrate the variable name has `DATABASE` written out in full, where in the knexfile it's `DB`. Make those match each other.