### PR TITLE
Expose the new status on pre-status hooks

### DIFF
--- a/lib/models/case.js
+++ b/lib/models/case.js
@@ -33,6 +33,7 @@ class Case {
       id: this.id,
       meta: {
         previous,
+        next: status,
         user
       },
       handler: () => Model.query().patchAndFetchById(this.id, { status })

--- a/package.json
+++ b/package.json
@@ -7,7 +7,8 @@
     "test": "npm run test:lint && npm run test:unit",
     "test:lint": "eslint .",
     "pretest:unit": "bin/taskflow migrate",
-    "test:unit": "NODE_ENV=test mocha ./test --recursive --exit --timeout 5000  --require dotenv/config"
+    "test:unit": "NODE_ENV=test mocha ./test --recursive --exit --timeout 5000  --require dotenv/config",
+    "test:db": "docker run -p 5432:5432 -e POSTGRES_USER=taskflow-test postgres"
   },
   "repository": {
     "type": "git",

--- a/test/integration/specs/case.js
+++ b/test/integration/specs/case.js
@@ -199,6 +199,21 @@ describe('/:case', () => {
         });
     });
 
+    it('includes the new status on pre-event hook metadata', () => {
+      const stub = sinon.stub().resolves();
+      this.flow.hook('pre-status:*:updated', stub);
+      return request(this.app)
+        .put(`/${id}/status`)
+        .set('Content-type', 'application/json')
+        .send({ status: 'updated' })
+        .expect(200)
+        .then(() => {
+          assert.equal(stub.calledOnce, true, 'Hook was called exactly once');
+          const meta = stub.lastCall.args[0].meta;
+          assert.equal(meta.next, 'updated', 'Hook metadata contains the new status');
+        });
+    });
+
   });
 
 });


### PR DESCRIPTION
When we have a hook that runs before a status change it should have the new target status exposed in the event metadata without needing to parse the event name.