### PR TITLE
Add middleware before and after case fetch

### DIFF
--- a/lib/decorator/index.js
+++ b/lib/decorator/index.js
@@ -1,3 +1,0 @@
-module.exports = (decorator) => {
-  return (data) => decorator(data);
-};

--- a/lib/decorator/index.js
+++ b/lib/decorator/index.js
@@ -1,0 +1,3 @@
+module.exports = (decorator) => {
+  return (data) => decorator(data);
+};

--- a/lib/index.js
+++ b/lib/index.js
@@ -1,27 +1,30 @@
 const { Router } = require('express');
 const { json } = require('body-parser');
-
+const { get } = require('lodash');
 const Database = require('./db');
 const router = require('./router');
 const Hooks = require('./hooks');
 
 const Case = require('./models/case');
 
-module.exports = ({ db, middleware } = {}) => {
-
-  const models = Database.connect(db);
-
-  Case.db(models);
+module.exports = (settings = {}) => {
+  const db = Database.connect(settings.db);
+  Case.db(db);
 
   const flow = Router();
   const hooks = Hooks.init();
+
+  const middleware = {
+    before: get(settings, 'middleware.before', []),
+    after: get(settings, 'middleware.after', [])
+  };
 
   flow.use(json({ extended: true }));
 
   flow.use(router({ hooks, middleware }));
 
   flow.hook = (event, fn) => hooks.create(event, fn);
-  flow.migrate = () => Database.migrate(db);
+  flow.migrate = () => Database.migrate(settings.db);
 
   flow.db = db;
 

--- a/lib/index.js
+++ b/lib/index.js
@@ -7,21 +7,21 @@ const Hooks = require('./hooks');
 
 const Case = require('./models/case');
 
-module.exports = (settings = {}) => {
+module.exports = ({ db, middleware } = {}) => {
 
-  const db = Database.connect(settings.db);
+  const models = Database.connect(db);
 
-  Case.db(db);
+  Case.db(models);
 
   const flow = Router();
   const hooks = Hooks.init();
 
   flow.use(json({ extended: true }));
 
-  flow.use(router({ hooks }));
+  flow.use(router({ hooks, middleware }));
 
   flow.hook = (event, fn) => hooks.create(event, fn);
-  flow.migrate = () => Database.migrate(settings.db);
+  flow.migrate = () => Database.migrate(db);
 
   flow.db = db;
 

--- a/lib/router/index.js
+++ b/lib/router/index.js
@@ -1,16 +1,9 @@
 const { Router } = require('express');
 const CaseRouter = require('./case');
 const Case = require('../models/case');
-const { get, isEmpty, flattenDeep } = require('lodash');
+const { isEmpty, flattenDeep } = require('lodash');
 
-module.exports = options => {
-  const hooks = options.hooks;
-
-  const middleware = {
-    before: get(options, 'middleware.before', []),
-    after: get(options, 'middleware.after', [])
-  };
-
+module.exports = ({ hooks, middleware }) => {
   const router = Router();
 
   router.use((req, res, next) => {

--- a/lib/router/index.js
+++ b/lib/router/index.js
@@ -3,10 +3,13 @@ const CaseRouter = require('./case');
 const Case = require('../models/case');
 const { get, isEmpty, flattenDeep } = require('lodash');
 
-module.exports = ({ hooks, middleware }) => {
+module.exports = options => {
+  const hooks = options.hooks;
 
-  middleware.before = get(middleware, 'before', []);
-  middleware.after = get(middleware, 'after', []);
+  const middleware = {
+    before: get(options, 'middleware.before', []),
+    after: get(options, 'middleware.after', [])
+  };
 
   const router = Router();
 

--- a/lib/router/index.js
+++ b/lib/router/index.js
@@ -5,6 +5,9 @@ const { isEmpty, flattenDeep } = require('lodash');
 
 module.exports = ({ hooks, middleware }) => {
 
+  middleware.before = middleware.before || [];
+  middleware.after = middleware.after || [];
+
   const router = Router();
 
   router.use((req, res, next) => {

--- a/lib/router/index.js
+++ b/lib/router/index.js
@@ -1,12 +1,12 @@
 const { Router } = require('express');
 const CaseRouter = require('./case');
 const Case = require('../models/case');
-const { isEmpty, flattenDeep } = require('lodash');
+const { get, isEmpty, flattenDeep } = require('lodash');
 
 module.exports = ({ hooks, middleware }) => {
 
-  middleware.before = middleware.before || [];
-  middleware.after = middleware.after || [];
+  middleware.before = get(middleware, 'before', []);
+  middleware.after = get(middleware, 'after', []);
 
   const router = Router();
 

--- a/lib/router/index.js
+++ b/lib/router/index.js
@@ -15,9 +15,6 @@ module.exports = ({ hooks, middleware }) => {
   });
 
   const fetchCases = (req, res, next) => {
-    console.log('in fetch cases');
-    console.log(res.respondWith);
-
     return Promise.resolve()
       .then(() => {
         if (isEmpty(req.query)) {
@@ -33,10 +30,7 @@ module.exports = ({ hooks, middleware }) => {
       .catch(next);
   };
 
-  const returnCases = (res, req, next) => {
-    console.log('in return cases');
-    console.log(res.respondWith);
-
+  const returnCases = (req, res, next) => {
     return Promise.resolve()
       .then(() => {
         res.respondWith(req.cases);
@@ -44,9 +38,7 @@ module.exports = ({ hooks, middleware }) => {
       .catch(next);
   };
 
-  const fetchCaseMiddleware = flattenDeep([middleware.before, fetchCases, middleware.after, returnCases]);
-  console.log(fetchCaseMiddleware);
-  router.get('/', fetchCaseMiddleware);
+  router.get('/', flattenDeep([middleware.before, fetchCases, middleware.after, returnCases]));
 
   router.post('/', (req, res, next) => {
     return Promise.resolve()

--- a/lib/router/index.js
+++ b/lib/router/index.js
@@ -1,9 +1,9 @@
 const { Router } = require('express');
 const CaseRouter = require('./case');
 const Case = require('../models/case');
-const { isEmpty } = require('lodash');
+const { isEmpty, flattenDeep } = require('lodash');
 
-module.exports = ({ hooks }) => {
+module.exports = ({ hooks, middleware }) => {
 
   const router = Router();
 
@@ -14,7 +14,10 @@ module.exports = ({ hooks }) => {
     next();
   });
 
-  router.get('/', (req, res, next) => {
+  const fetchCases = (req, res, next) => {
+    console.log('in fetch cases');
+    console.log(res.respondWith);
+
     return Promise.resolve()
       .then(() => {
         if (isEmpty(req.query)) {
@@ -23,11 +26,27 @@ module.exports = ({ hooks }) => {
 
         return Case.filterByParams(req.query);
       })
-      .then(data => {
-        res.respondWith(data);
+      .then(cases => {
+        req.cases = cases;
+      })
+      .then(() => next())
+      .catch(next);
+  };
+
+  const returnCases = (res, req, next) => {
+    console.log('in return cases');
+    console.log(res.respondWith);
+
+    return Promise.resolve()
+      .then(() => {
+        res.respondWith(req.cases);
       })
       .catch(next);
-  });
+  };
+
+  const fetchCaseMiddleware = flattenDeep([middleware.before, fetchCases, middleware.after, returnCases]);
+  console.log(fetchCaseMiddleware);
+  router.get('/', fetchCaseMiddleware);
 
   router.post('/', (req, res, next) => {
     return Promise.resolve()


### PR DESCRIPTION
You can now provide middleware to execute before and after cases are fetched from the database.

e.g.: 
```
const flow = Taskflow({
    db: settings.taskflowDB,
    middleware: {
      before: [ /* stuff to execute before */ ],
      after: [ /* stuff to execute after */ ]
    }
  });
```

In `after` middleware, the fetched cases will be available in `req.cases`. Make any modifications you need and then save back to `req.cases` before calling the next middleware.

