### PR TITLE
Refactor decorators

### DIFF
--- a/README.md
+++ b/README.md
@@ -130,6 +130,35 @@ Calling these methods will trigger events and related hooks, so care should be t
 
 If hooks cause updates to case statuses or data then any subsequent hooks will be called with the updated values.
 
+## Decorators
+
+Decorator functions can be defined to add additional properties to cases at read time.
+
+Decorators take the case object as an argument, and should return a modifed case with any custom properties applied.
+
+To define a decorator function:
+
+```js
+const flow = taskflow();
+flow
+  .decorate(case => {
+    return { ...case, customProperty: 'my custom property' };
+  });
+```
+
+Decorator functions can be asynchronous, and should return promises (or be `async` functions).
+
+```js
+const flow = taskflow();
+flow
+  .decorate(case => {
+    return Database.query()
+      .then(result => {
+        return { ...case, customProperty: result.propertyFromDatabase };
+      });
+  });
+```
+
 ## Running tests
 
 The tests are built to run against a real postgres database, so to run the unit tests you will need a databse running.

--- a/lib/decorators/index.js
+++ b/lib/decorators/index.js
@@ -3,7 +3,11 @@ module.exports = {
 
     const decorators = [];
 
-    const decorate = c => decorators.reduce((promise, fn) => promise.then(obj => fn(obj)), Promise.resolve(c));
+    const decorate = c => {
+      return decorators.reduce((promise, fn) => {
+        return promise.then(c => fn(c));
+      }, Promise.resolve(c));
+    };
 
     return {
       add: fn => {

--- a/lib/decorators/index.js
+++ b/lib/decorators/index.js
@@ -1,0 +1,23 @@
+module.exports = {
+  init: () => {
+
+    const decorators = [];
+
+    const decorate = c => decorators.reduce((promise, fn) => promise.then(obj => fn(obj)), Promise.resolve(c));
+
+    return {
+      add: fn => {
+        if (typeof fn !== 'function') {
+          throw new Error(`Invalid decorator type: ${typeof fn}`);
+        }
+        decorators.push(fn);
+      },
+      apply: c => {
+        if (Array.isArray(c)) {
+          return Promise.all(c.map(decorate));
+        }
+        return decorate(c);
+      }
+    };
+  }
+};

--- a/lib/index.js
+++ b/lib/index.js
@@ -3,6 +3,7 @@ const { json } = require('body-parser');
 const Database = require('./db');
 const router = require('./router');
 const Hooks = require('./hooks');
+const Decorators = require('./decorators');
 
 const Case = require('./models/case');
 
@@ -12,17 +13,16 @@ module.exports = (settings = {}) => {
 
   const flow = Router();
   const hooks = Hooks.init();
+  const decorators = Decorators.init();
 
   flow.use(json({ extended: true }));
 
-  const flowRouter = router({ hooks });
-
-  flow.use(flowRouter);
+  flow.use(router({ hooks, decorators }));
 
   flow.hook = (event, fn) => hooks.create(event, fn);
   flow.migrate = () => Database.migrate(settings.db);
 
-  flow.decorate = flowRouter.decorator;
+  flow.decorate = fn => decorators.add(fn);
 
   flow.db = db;
 

--- a/lib/router/case.js
+++ b/lib/router/case.js
@@ -1,11 +1,11 @@
 const { Router } = require('express');
 const Case = require('../models/case');
 
-module.exports = ({ hooks, caseDecorator }) => {
+module.exports = ({ hooks }) => {
 
   const router = Router();
 
-  router.get('/', caseDecorator, (req, res, next) => {
+  router.get('/', (req, res, next) => {
     res.respondWith(req.case);
   });
 

--- a/lib/router/cases.js
+++ b/lib/router/cases.js
@@ -1,7 +1,7 @@
 const { Router } = require('express');
 const Case = require('../models/case');
 
-module.exports = ({ caseDecorator }) => {
+module.exports = () => {
   const router = Router();
 
   const fetchCases = (req, res, next) => {
@@ -28,11 +28,7 @@ module.exports = ({ caseDecorator }) => {
       .catch(next);
   };
 
-  const decorator = Router();
-  router.decorator = decorator;
-
   router.use(fetchCases);
-  router.use(caseDecorator);
   router.use(returnCases);
 
   return router;

--- a/lib/router/index.js
+++ b/lib/router/index.js
@@ -3,9 +3,7 @@ const caseRouter = require('./case');
 const Case = require('../models/case');
 const casesRouter = require('./cases');
 
-const caseDecorator = Router();
-
-module.exports = ({ hooks }) => {
+module.exports = ({ hooks, decorators }) => {
   const router = Router();
 
   router.param('caseId', (req, res, next, caseId) => {
@@ -20,14 +18,17 @@ module.exports = ({ hooks }) => {
 
   router.use((req, res, next) => {
     res.respondWith = (data, meta) => {
-      res.json({ data, meta });
+      decorators.apply(data)
+        .then(decorated => {
+          res.json({ data: decorated, meta });
+        });
     };
     next();
   });
 
-  router.get('/', casesRouter({ caseDecorator }));
+  router.get('/', casesRouter());
 
-  router.use('/:caseId', caseRouter({ caseDecorator, hooks }));
+  router.use('/:caseId', caseRouter({ hooks }));
 
   router.post('/', (req, res, next) => {
     return Promise.resolve()
@@ -42,8 +43,6 @@ module.exports = ({ hooks }) => {
       })
       .catch(next);
   });
-
-  router.decorator = caseDecorator;
 
   return router;
 };

--- a/test/integration/specs/case.js
+++ b/test/integration/specs/case.js
@@ -57,6 +57,35 @@ describe('/:case', () => {
         });
     });
 
+    it('applies single decorator to cases', () => {
+      this.flow.decorate(c => ({ ...c, decorated: true }));
+      return request(this.app)
+        .get(`/${id}`)
+        .expect(response => {
+          assert.equal(response.body.data.decorated, true, '`decorated` property is added to the model');
+        });
+    });
+
+    it('applies multiple decorators to cases', () => {
+      this.flow.decorate(c => ({ ...c, decorated: true }));
+      this.flow.decorate(c => ({ ...c, decoratedAgain: true }));
+      return request(this.app)
+        .get(`/${id}`)
+        .expect(response => {
+          assert.equal(response.body.data.decorated, true, '`decorated` property is added to the model');
+          assert.equal(response.body.data.decoratedAgain, true, '`decoratedAgain` property is added to the model');
+        });
+    });
+
+    it('supports asynchronous decorators', () => {
+      this.flow.decorate(c => Promise.resolve({ ...c, decorated: true }));
+      return request(this.app)
+        .get(`/${id}`)
+        .expect(response => {
+          assert.equal(response.body.data.decorated, true, '`decorated` property is added to the model');
+        });
+    });
+
   });
 
   describe('PUT /:case', () => {

--- a/test/integration/specs/list.js
+++ b/test/integration/specs/list.js
@@ -174,4 +174,48 @@ describe('GET /', () => {
         ]);
       });
   });
+
+  it('applies a single decorator to cases', () => {
+    this.flow.decorate(c => ({ ...c, decorated: true }));
+    return request(this.app)
+      .get('/')
+      .expect(200)
+      .expect(response => {
+        response.body.data.forEach(c => {
+          assert.equal(c.decorated, true, 'Decorator has been applied to each case');
+        });
+      });
+  });
+
+  it('applies multiple decorators to cases', () => {
+    this.flow.decorate(c => ({ ...c, decorated: true }));
+    this.flow.decorate(c => ({ ...c, decoratedAgain: true }));
+    return request(this.app)
+      .get('/')
+      .expect(200)
+      .expect(response => {
+        response.body.data.forEach(c => {
+          assert.equal(c.decorated, true, 'First decorator has been applied to each case');
+          assert.equal(c.decoratedAgain, true, 'Second decorator has been applied to each case');
+        });
+      });
+  });
+
+  it('applies multiple async decorators to cases in series', () => {
+    this.flow.decorate(c => ({ ...c, substr: c.id.substring(0, 10) }));
+    this.flow.decorate(c => ({ ...c, upper: c.substr.toUpperCase() }));
+    return request(this.app)
+      .get('/')
+      .expect(200)
+      .expect(response => {
+        assert.deepEqual(response.body.data.map(o => o.upper), [
+          'FB38E7BE-3',
+          '0DDFEA8D-3',
+          'E384F4FC-B',
+          'A5AA8804-4',
+          '1DA5D32E-4'
+        ]);
+      });
+  });
+
 });


### PR DESCRIPTION
* Moves the application logic into `respondWith` in order to keep the logic encapsulated
* Refactors decorator functions to take a case object as an argument and return the decorated case
* Allows for the application of multiple decorators applied in series