### PR TITLE
Normalise input objects in decorators

### DIFF
--- a/lib/decorators/index.js
+++ b/lib/decorators/index.js
@@ -4,6 +4,9 @@ module.exports = {
     const decorators = [];
 
     const decorate = c => {
+      if (typeof c.toJSON === 'function') {
+        c = c.toJSON();
+      }
       return decorators.reduce((promise, fn) => {
         return promise.then(c => fn(c));
       }, Promise.resolve(c));

--- a/lib/router/index.js
+++ b/lib/router/index.js
@@ -21,7 +21,8 @@ module.exports = ({ hooks, decorators }) => {
       decorators.apply(data)
         .then(decorated => {
           res.json({ data: decorated, meta });
-        });
+        })
+        .catch(next);
     };
     next();
   });

--- a/test/integration/specs/create.js
+++ b/test/integration/specs/create.js
@@ -119,4 +119,24 @@ describe('POST /', () => {
       });
   });
 
+  it('applies decorators to the returned data', () => {
+    this.flow.decorate(c => {
+      return {
+        ...c,
+        data: { ...c.data, upper: c.data.test.toUpperCase() }
+      };
+    });
+    return Promise.resolve()
+      .then(() => {
+        return request(this.app)
+          .post('/')
+          .set('Content-type', 'application/json')
+          .send({ test: 'data' })
+          .expect(200)
+          .expect(response => {
+            assert.equal(response.body.data.data.upper, 'DATA');
+          });
+      });
+  });
+
 });


### PR DESCRIPTION
Sometimes an instance of the `Case` class is the parameter to `respondWith` and sometimes it a plain object.

Ensure that `Case` instances are converted to plain objects first.