### PR TITLE
Comment is now wrapped in meta

### DIFF
--- a/lib/router/case.js
+++ b/lib/router/case.js
@@ -26,7 +26,7 @@ module.exports = ({ hooks }) => {
   router.put('/status', (req, res, next) => {
     return Promise.resolve()
       .then(() => {
-        return req.case.status(req.body.status, { hooks, user: req.user, payload: req.body });
+        return req.case.status(req.body.status, { hooks, user: req.user, payload: req.body.meta });
       })
       .then(() => {
         return Case.find(req.case.id);

--- a/test/integration/specs/case.js
+++ b/test/integration/specs/case.js
@@ -248,7 +248,7 @@ describe('/:case', () => {
     });
 
     it('includes the request payload in the hook metadata when changing status', () => {
-      const payload = { status: 'updated', reason: 'some reason' };
+      const payload = { status: 'updated', meta: { comment: 'some reason' } };
       const stub = sinon.stub().resolves();
       this.flow.hook('pre-status:*:*', stub);
       return request(this.app)
@@ -259,7 +259,7 @@ describe('/:case', () => {
         .then(() => {
           assert.equal(stub.calledOnce, true, 'Hook was called exactly once');
           const meta = stub.lastCall.args[0].meta;
-          assert.deepEqual(meta.payload, payload, 'Hook metadata contains the request payload');
+          assert.deepEqual(meta.payload, payload.meta, 'Hook metadata contains the request payload metadata');
         });
     });
 
@@ -267,7 +267,7 @@ describe('/:case', () => {
       return request(this.app)
         .put(`/${id}/status`)
         .set('Content-type', 'application/json')
-        .send({ status: 'updated', comment: 'testing the activity log' })
+        .send({ status: 'updated', meta: { comment: 'testing the activity log' } })
         .expect(200)
         .then(() => {
           return ActivityLog.query(this.flow.db).findOne({ comment: 'testing the activity log' })


### PR DESCRIPTION
`asl-public-api` now wraps the status change comment in a meta property, so we need to unwrap it here.