### PR TITLE
Support Boolean values for sort direction parameter

### DIFF
--- a/lib/models/case.js
+++ b/lib/models/case.js
@@ -157,8 +157,11 @@ class Case {
     if (!sort.column) {
       return query;
     }
+    if (typeof sort.ascending === 'string') {
+      sort.ascending = sort.ascending === 'true';
+    }
     return query
-      .orderBy(sort.column, sort.ascending === 'true' ? 'asc' : 'desc');
+      .orderBy(sort.column, sort.ascending ? 'asc' : 'desc');
   }
 }
 


### PR DESCRIPTION
Forcing the parameters to be a string `'true'` or `'false'` is painful for implementation not passing directly from the query string.