### PR TITLE
Add a flag to decorators to disable in lists

### DIFF
--- a/lib/decorators/index.js
+++ b/lib/decorators/index.js
@@ -3,25 +3,28 @@ module.exports = {
 
     const decorators = [];
 
-    const decorate = (c, user) => {
+    const decorate = (c, user, params = {}) => {
       if (typeof c.toJSON === 'function') {
         c = c.toJSON();
       }
-      return decorators.reduce((promise, fn) => {
-        return promise.then(c => fn(c, user));
+      return decorators.reduce((promise, decorator) => {
+        if (params.isList && decorator.params.list === false) {
+          return promise;
+        }
+        return promise.then(c => decorator.fn(c, user));
       }, Promise.resolve(c));
     };
 
     return {
-      add: fn => {
+      add: (fn, params = {}) => {
         if (typeof fn !== 'function') {
           throw new Error(`Invalid decorator type: ${typeof fn}`);
         }
-        decorators.push(fn);
+        decorators.push({ fn, params });
       },
       apply: (c, user) => {
         if (Array.isArray(c)) {
-          return Promise.all(c.map(task => decorate(task, user)));
+          return Promise.all(c.map(task => decorate(task, user, { isList: true })));
         }
         return decorate(c, user);
       }

--- a/lib/index.js
+++ b/lib/index.js
@@ -31,7 +31,7 @@ module.exports = (settings = {}) => {
   flow.hook = (event, fn) => hooks.create(event, fn);
   flow.migrate = () => Database.migrate(settings.db);
 
-  flow.decorate = fn => decorators.add(fn);
+  flow.decorate = (fn, params) => decorators.add(fn, params);
 
   flow.hook('create', activityLogger(db));
   flow.hook('update', activityLogger(db));

--- a/test/integration/specs/case.js
+++ b/test/integration/specs/case.js
@@ -87,6 +87,19 @@ describe('/:case', () => {
         });
     });
 
+    it('includes decorators configured with `list: false`', () => {
+      this.flow.decorate(c => ({ ...c, decorated: true }));
+      this.flow.decorate(c => ({ ...c, decoratedAgain: true }));
+      this.flow.decorate(c => ({ ...c, decoratedList: true }), { list: false });
+      return request(this.app)
+        .get(`/${id}`)
+        .expect(response => {
+          assert.equal(response.body.data.decorated, true, '`decorated` property is added to the model');
+          assert.equal(response.body.data.decoratedAgain, true, '`decoratedAgain` property is added to the model');
+          assert.equal(response.body.data.decoratedList, true, '`decoratedList` property is added to the model');
+        });
+    });
+
   });
 
   describe('PUT /:case', () => {

--- a/test/integration/specs/list.js
+++ b/test/integration/specs/list.js
@@ -218,4 +218,20 @@ describe('GET /', () => {
       });
   });
 
+  it('ignores decorators defined with `list: false`', () => {
+    this.flow.decorate(c => ({ ...c, decorated: true }));
+    this.flow.decorate(c => ({ ...c, decoratedAgain: true }));
+    this.flow.decorate(c => ({ ...c, decoratedList: true }), { list: false });
+    return request(this.app)
+      .get('/')
+      .expect(200)
+      .expect(response => {
+        response.body.data.forEach(c => {
+          assert.equal(c.decorated, true, 'First decorator has been applied to each case');
+          assert.equal(c.decoratedAgain, true, 'Second decorator has been applied to each case');
+          assert.equal(c.decoratedList, undefined, 'List decorator has not been applied');
+        });
+      });
+  });
+
 });


### PR DESCRIPTION
Some decorators include potentially expensive data operations that are not reuiqred in list views, but are required on per-record requests to show task detail.

Add a `list: false` flag to decorators to be able to disable them in list views.