### PR TITLE
Add `patch` method to models and event wrappers

### DIFF
--- a/lib/hooks/event-wrapper.js
+++ b/lib/hooks/event-wrapper.js
@@ -55,6 +55,19 @@ class EventWrapper {
       });
   }
 
+  patch(data) {
+    if (this.isPreCreateHook) {
+      return console.error('WARNING: cannot modify case models in pre-create hooks.');
+    }
+    if (this.isPreUpdateHook) {
+      return console.error('WARNING: cannot modify case models in pre-update hooks.');
+    }
+    return Case.find(this.id)
+      .then(model => {
+        return model.patch(data, { ...this.meta, hooks: this.hooks });
+      });
+  }
+
 }
 
 module.exports = EventWrapper;

--- a/lib/models/case.js
+++ b/lib/models/case.js
@@ -47,6 +47,13 @@ class Case {
     });
   }
 
+  patch(data, opts) {
+    return Case.query().findById(this.id)
+      .then(result => {
+        return this.update({ ...result.data, ...data }, opts);
+      });
+  }
+
   update(data, { hooks, user, payload }) {
     return hooks.invoke({
       event: 'update',

--- a/test/integration/specs/case.js
+++ b/test/integration/specs/case.js
@@ -34,6 +34,10 @@ describe('/:case', () => {
       });
   });
 
+  afterEach(done => {
+    this.flow.db.destroy(done);
+  });
+
   describe('GET /:case', () => {
 
     it('responds 200 for a valid id', () => {

--- a/test/integration/specs/create.js
+++ b/test/integration/specs/create.js
@@ -18,6 +18,10 @@ describe('POST /', () => {
     return reset();
   });
 
+  afterEach(done => {
+    this.flow.db.destroy(done);
+  });
+
   it('responds 200', () => {
     return request(this.app)
       .post('/')

--- a/test/integration/specs/list.js
+++ b/test/integration/specs/list.js
@@ -67,6 +67,10 @@ describe('GET /', () => {
       });
   });
 
+  afterEach(done => {
+    this.flow.db.destroy(done);
+  });
+
   it('responds 200', () => {
     return request(this.app)
       .get('/')


### PR DESCRIPTION
The most common use case for updating things is not to provide the complete state, but only the proerties which should be updated.

Leave `update` to expect a full state for backwards compatibilty reasons, but add a `patch` method to support this use case.