### PR TITLE
Set hooks as a static property on the case model

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -5,6 +5,7 @@ pipeline:
     environment:
       TASKFLOW_POSTGRES_HOST: database
       TASKFLOW_POSTGRES_USER: taskflow-test
+      TASKFLOW_POSTGRES_PASSWORD: test-password
     commands:
       - npm ci
       - npm test
@@ -32,4 +33,5 @@ services:
   database:
     image: postgres
     environment:
+      - POSTGRES_PASSWORD=test-password
       - POSTGRES_USER=taskflow-test

--- a/lib/hooks/event-wrapper.js
+++ b/lib/hooks/event-wrapper.js
@@ -3,13 +3,12 @@ const Case = require('../models/case');
 
 class EventWrapper {
 
-  constructor({ id, meta = {}, event, hooks }) {
+  constructor({ id, meta = {}, event }) {
     this.id = id;
     this.meta = meta;
     this.event = event;
     this.comment = meta.comment || get(meta, 'payload.meta.comment');
 
-    Object.defineProperty(this, 'hooks', { value: hooks });
     Object.defineProperty(this, 'isPreStatusHook', { value: !!event.match(/^pre-status/) });
     Object.defineProperty(this, 'isPreUpdateHook', { value: !!event.match(/^pre-update/) });
     Object.defineProperty(this, 'isPreCreateHook', { value: !!event.match(/^pre-create/) });
@@ -38,7 +37,7 @@ class EventWrapper {
     }
     return Case.find(this.id)
       .then(model => {
-        return model.status(status, { ...this.meta, hooks: this.hooks });
+        return model.status(status, { ...this.meta });
       });
   }
 
@@ -51,7 +50,7 @@ class EventWrapper {
     }
     return Case.find(this.id)
       .then(model => {
-        return model.update(data, { ...this.meta, hooks: this.hooks });
+        return model.update(data, { ...this.meta });
       });
   }
 
@@ -64,7 +63,7 @@ class EventWrapper {
     }
     return Case.find(this.id)
       .then(model => {
-        return model.patch(data, { ...this.meta, hooks: this.hooks });
+        return model.patch(data, { ...this.meta });
       });
   }
 

--- a/lib/index.js
+++ b/lib/index.js
@@ -13,6 +13,8 @@ module.exports = (settings = {}) => {
 
   const flow = Router();
   const hooks = Hooks.init();
+  Case.setHooks(hooks);
+
   const decorators = Decorators.init();
 
   const responder = (req, res) => (data, meta) => {

--- a/lib/models/case.js
+++ b/lib/models/case.js
@@ -26,7 +26,7 @@ class Case {
     };
   }
 
-  status(status, { hooks, user, payload }) {
+  status(status, { user, payload }) {
     const previous = this._status;
     if (!status) {
       throw new InvalidRequestError({ status: 'required' });
@@ -35,7 +35,7 @@ class Case {
       throw new InvalidRequestError({ status: 'invalid' });
     }
 
-    return hooks.invoke({
+    return Case.hooks.invoke({
       event: `status:${previous}:${status}`,
       id: this.id,
       meta: {
@@ -55,8 +55,8 @@ class Case {
       });
   }
 
-  update(data, { hooks, user, payload }) {
-    return hooks.invoke({
+  update(data, { user, payload }) {
+    return Case.hooks.invoke({
       event: 'update',
       id: this.id,
       meta: {
@@ -75,6 +75,13 @@ class Case {
   static db(db) {
     Object.defineProperty(this, 'Model', {
       value: Model.bindKnex(db),
+      configurable: true
+    });
+  }
+
+  static setHooks(hooks) {
+    Object.defineProperty(this, 'hooks', {
+      value: hooks,
       configurable: true
     });
   }
@@ -125,13 +132,13 @@ class Case {
     return query;
   }
 
-  static create(data, { hooks, user, payload }) {
+  static create(data, { user, payload }) {
     const model = {
       id: uuid(),
       status: 'new',
       data
     };
-    return hooks.invoke({
+    return Case.hooks.invoke({
       event: 'create',
       id: model.id,
       meta: {
@@ -178,8 +185,8 @@ class Case {
       .orderBy(sort.column, sort.ascending ? 'asc' : 'desc');
   }
 
-  comment(comment, { hooks, user, payload }) {
-    return hooks.invoke({
+  comment(comment, { user, payload }) {
+    return Case.hooks.invoke({
       event: 'comment',
       id: this.id,
       meta: {
@@ -196,12 +203,12 @@ class Case {
     return comment.changedBy === user.profile.id;
   }
 
-  updateComment(id, comment, { hooks, user, payload }) {
+  updateComment(id, comment, { user, payload }) {
     if (!this.userAuthoredComment(id, user)) {
       throw new UnauthorisedError('only comment authors may update a comment');
     }
 
-    return hooks.invoke({
+    return Case.hooks.invoke({
       event: 'update-comment',
       id: this.id,
       meta: {
@@ -214,12 +221,12 @@ class Case {
     });
   }
 
-  deleteComment(id, { hooks, user }) {
+  deleteComment(id, { user }) {
     if (!this.userAuthoredComment(id, user)) {
       throw new UnauthorisedError('only comment authors may delete a comment');
     }
 
-    return hooks.invoke({
+    return Case.hooks.invoke({
       event: 'delete-comment',
       id: this.id,
       meta: {

--- a/test/integration/specs/list.js
+++ b/test/integration/specs/list.js
@@ -116,11 +116,11 @@ describe('GET /', () => {
       .get('/?exclude[status]=autoresolved&exclude[status]=resolved')
       .expect(response => {
         assert.equal(response.body.data.length, 3, '3 records were returned');
-        assert.deepEqual(response.body.data.map(o => o.id), [
+        assert.deepEqual(response.body.data.map(o => o.id).sort(), [
           'e384f4fc-b647-40b6-b8f6-dddc6d9e93da',
           'a5aa8804-4658-458d-87b4-88a585c70cea',
           '1da5d32e-4ec8-4ebc-8f95-6b7983077e9b'
-        ]);
+        ].sort());
       });
   });
 
@@ -140,10 +140,10 @@ describe('GET /', () => {
       .get('/?status=with-ntco&status=resolved')
       .expect(response => {
         assert.equal(response.body.data.length, 2, '2 records were returned');
-        assert.deepEqual(response.body.data.map(o => o.id), [
+        assert.deepEqual(response.body.data.map(o => o.id).sort(), [
           'fb38e7be-386b-4681-9717-af9a7396b8ed',
           'e384f4fc-b647-40b6-b8f6-dddc6d9e93da'
-        ]);
+        ].sort());
       });
   });
 
@@ -152,12 +152,12 @@ describe('GET /', () => {
       .get('/?data[subject]=5b7bad13-f34b-4959-bd08-c6067ae2fcdd')
       .expect(response => {
         assert.equal(response.body.data.length, 4, '4 records were returned');
-        assert.deepEqual(response.body.data.map(o => o.id), [
+        assert.deepEqual(response.body.data.map(o => o.id).sort(), [
           'fb38e7be-386b-4681-9717-af9a7396b8ed',
           '0ddfea8d-31d9-4258-a545-b403a3fc4864',
           'e384f4fc-b647-40b6-b8f6-dddc6d9e93da',
           'a5aa8804-4658-458d-87b4-88a585c70cea'
-        ]);
+        ].sort());
       });
   });
 
@@ -177,10 +177,10 @@ describe('GET /', () => {
       .get('/?data[model]=pil&exclude[status]=autoresolved')
       .expect(response => {
         assert.equal(response.body.data.length, 2, '2 records were returned');
-        assert.deepEqual(response.body.data.map(o => o.id), [
+        assert.deepEqual(response.body.data.map(o => o.id).sort(), [
           'e384f4fc-b647-40b6-b8f6-dddc6d9e93da',
           '1da5d32e-4ec8-4ebc-8f95-6b7983077e9b'
-        ]);
+        ].sort());
       });
   });
 


### PR DESCRIPTION
There is only ever one instance of the `hooks` store in a normal execution, so rather than passing it around on all functions - making it impossible to actually call those functions from contexts where the hook store is not available - set it once as a static property of the `Case` model and use that property wherever hooks are required.