### PR TITLE
Expose Case class on top level exports

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -7,7 +7,7 @@ const Decorators = require('./decorators');
 const activityLogger = require('./activitylog/hooks/logger');
 const Case = require('./models/case');
 
-module.exports = (settings = {}) => {
+const init = (settings = {}) => {
   const db = Database.connect(settings.db);
   Case.db(db);
 
@@ -43,6 +43,11 @@ module.exports = (settings = {}) => {
   flow.hook('delete-comment', activityLogger(db));
 
   flow.db = db;
+  flow.Case = Case;
 
   return flow;
 };
+
+init.Case = Case;
+
+module.exports = init;


### PR DESCRIPTION
There's a lot of code in workflow doing `const Case = require('@ukhomeoffice/taskflow/lib/models/case')` which is kind of gnarly.

Instead make that class accessible as a property the top level require, and also of a taskflow instance.