### PR TITLE
Add method to terminate flows and resolve with a value in hooks

### DIFF
--- a/lib/constants/index.js
+++ b/lib/constants/index.js
@@ -1,0 +1,3 @@
+module.exports = {
+  TERMINATED: Symbol.for('TERMINATED')
+};

--- a/lib/hooks/event-wrapper.js
+++ b/lib/hooks/event-wrapper.js
@@ -1,5 +1,6 @@
 const { get } = require('lodash');
 const Task = require('../models/task');
+const { TERMINATED } = require('../constants');
 
 class EventWrapper {
 
@@ -65,6 +66,21 @@ class EventWrapper {
       .then(model => {
         return model.patch(data, { ...this.meta });
       });
+  }
+
+  redirect(result) {
+    if (this.event !== 'pre-create') {
+      throw new Error('Can only `redirect` on `pre-create` events');
+    }
+    if (typeof result === 'string') {
+      result = { id: result };
+    }
+    const { id } = result;
+    if (!id) {
+      throw new Error('`redirect` must be called with an id or an object with an id property');
+    }
+    Object.defineProperty(this, 'terminated', { value: TERMINATED, configurable: false });
+    Object.defineProperty(this, 'result', { value: result, configurable: false });
   }
 
 }

--- a/lib/hooks/store.js
+++ b/lib/hooks/store.js
@@ -1,5 +1,13 @@
 const { every } = require('lodash');
 const EventWrapper = require('./event-wrapper');
+const { TERMINATED } = require('../constants');
+
+class Termination extends Error {
+  constructor(result) {
+    super('terminated');
+    this.result = result;
+  }
+}
 
 class Store {
 
@@ -48,7 +56,12 @@ class Store {
       return hooks.reduce((promise, hook) => {
         return promise
           .then(() => model.populate())
-          .then(() => hook.fn(model));
+          .then(() => hook.fn(model))
+          .then(() => {
+            if (model.terminated === TERMINATED) {
+              throw new Termination(model.result);
+            }
+          });
       }, Promise.resolve());
     };
 
@@ -58,7 +71,13 @@ class Store {
       // call event handler
       .then(() => handler())
       // trigger post-event hooks in series
-      .then(result => chain(after, event).then(() => result));
+      .then(result => chain(after, event).then(() => result))
+      .catch(err => {
+        if (err instanceof Termination) {
+          return err.result;
+        }
+        throw err;
+      });
   }
 
 }

--- a/test/unit/hooks/event-wrapper.js
+++ b/test/unit/hooks/event-wrapper.js
@@ -31,6 +31,11 @@ describe('Hooks EventWrapper', () => {
       assert.equal(typeof event.setStatus, 'function');
     });
 
+    it('exposes a `redirect` function on pre-create hooks', () => {
+      const event = new EventWrapper({ ...model, event: 'pre-create' });
+      assert.equal(typeof event.redirect, 'function');
+    });
+
   });
 
 });


### PR DESCRIPTION
Proposes `model.send()` that will prevent execution of any downstream flow or hooks, but will allow the invocation to resolve with a value provided.