### PR TITLE
Use transactions to handle errors in hooks

### DIFF
--- a/lib/activitylog/hooks/logger.js
+++ b/lib/activitylog/hooks/logger.js
@@ -1,9 +1,9 @@
 const { get } = require('lodash');
 const ActivityLog = require('../../db/activity-log');
 
-module.exports = db => {
+module.exports = () => {
   return model => {
-    return ActivityLog.query(db).insert({
+    return ActivityLog.query(model.transaction).insert({
       caseId: model.id,
       changedBy: get(model, 'meta.user.profile.id'),
       eventName: get(model, 'event'),

--- a/lib/hooks/event-wrapper.js
+++ b/lib/hooks/event-wrapper.js
@@ -4,7 +4,7 @@ const { TERMINATED } = require('../constants');
 
 class EventWrapper {
 
-  constructor({ id, meta = {}, event }) {
+  constructor({ id, meta = {}, event, transaction }) {
     this.id = id;
     this.meta = meta;
     this.event = event;
@@ -13,13 +13,14 @@ class EventWrapper {
     Object.defineProperty(this, 'isPreStatusHook', { value: !!event.match(/^pre-status/) });
     Object.defineProperty(this, 'isPreUpdateHook', { value: !!event.match(/^pre-update/) });
     Object.defineProperty(this, 'isPreCreateHook', { value: !!event.match(/^pre-create/) });
+    Object.defineProperty(this, 'transaction', { value: transaction });
   }
 
   populate() {
     if (this.event === 'pre-create') {
       return Promise.resolve();
     }
-    return Task.find(this.id)
+    return Task.find(this.id, this.transaction)
       .then(model => {
         return model.toJSON();
       })
@@ -36,7 +37,7 @@ class EventWrapper {
     if (this.isPreStatusHook) {
       return console.error('WARNING: cannot modify case models in pre-status hooks.');
     }
-    return Task.find(this.id)
+    return Task.find(this.id, this.transaction)
       .then(model => {
         return model.status(status, { ...this.meta });
       });
@@ -49,7 +50,7 @@ class EventWrapper {
     if (this.isPreUpdateHook) {
       return console.error('WARNING: cannot modify case models in pre-update hooks.');
     }
-    return Task.find(this.id)
+    return Task.find(this.id, this.transaction)
       .then(model => {
         return model.update(data, { ...this.meta });
       });
@@ -62,7 +63,7 @@ class EventWrapper {
     if (this.isPreUpdateHook) {
       return console.error('WARNING: cannot modify case models in pre-update hooks.');
     }
-    return Task.find(this.id)
+    return Task.find(this.id, this.transaction)
       .then(model => {
         return model.patch(data, { ...this.meta });
       });
@@ -81,6 +82,10 @@ class EventWrapper {
     }
     Object.defineProperty(this, 'terminated', { value: TERMINATED, configurable: false });
     Object.defineProperty(this, 'result', { value: result, configurable: false });
+  }
+
+  find(id) {
+    return Task.find(id, this.transaction);
   }
 
 }

--- a/lib/hooks/store.js
+++ b/lib/hooks/store.js
@@ -47,12 +47,12 @@ class Store {
     return this._hooks.filter(hook => hook.re.test(event));
   }
 
-  invoke({ event, id, meta, handler }) {
+  invoke({ event, id, meta, handler, transaction }) {
     const before = this.hooks(`pre-${event}`);
     const after = this.hooks(event);
 
     const chain = (hooks, e) => {
-      const model = new EventWrapper({ event: e, id, meta, hooks: this });
+      const model = new EventWrapper({ event: e, id, meta, hooks: this, transaction });
       return hooks.reduce((promise, hook) => {
         return promise
           .then(() => model.populate())

--- a/lib/index.js
+++ b/lib/index.js
@@ -1,5 +1,6 @@
 const { Router } = require('express');
 const { json } = require('body-parser');
+const { transaction } = require('objection');
 const Database = require('./db');
 const router = require('./router');
 const Hooks = require('./hooks');
@@ -26,9 +27,40 @@ const init = (settings = {}) => {
 
   flow.responder = responder;
 
+  flow.use((req, res, next) => {
+    const send = responder(req, res);
+    res.respondWith = (data, meta) => {
+      req.transaction.commit()
+        .then(() => {
+          send(data, meta);
+        })
+        .catch(e => {
+          res.status(500).json({ message: e.message, stack: e.stack });
+        });
+    };
+    next();
+  });
+
   flow.use(json({ extended: true }));
 
-  flow.use(router({ hooks, responder }));
+  flow.use((req, res, next) => {
+    transaction.start(db)
+      .then(trx => {
+        req.transaction = trx;
+      })
+      .then(() => next())
+      .catch(next);
+  });
+
+  flow.use(router());
+
+  flow.use((err, req, res, next) => {
+    if (req.transaction) {
+      return req.transaction.rollback()
+        .then(() => next(err), next);
+    }
+    next(err);
+  });
 
   flow.hook = (event, fn) => hooks.create(event, fn);
   flow.migrate = () => Database.migrate(settings.db);

--- a/lib/models/task.js
+++ b/lib/models/task.js
@@ -6,13 +6,15 @@ const normaliseComments = require('../activitylog/normalise-comments');
 
 class Case {
 
-  constructor(model = {}) {
+  constructor(model = {}, transaction) {
     this.id = model.id;
     this._status = model.status;
     this._data = model.data;
     this._activityLog = normaliseComments(model.activityLog || []);
     this._createdAt = model.createdAt;
     this._updatedAt = model.updatedAt;
+
+    Object.defineProperty(this, 'transaction', { value: transaction });
   }
 
   toJSON() {
@@ -44,12 +46,13 @@ class Case {
         user,
         payload
       },
-      handler: () => Case.query().patchAndFetchById(this.id, { status })
+      transaction: this.transaction,
+      handler: () => Case.query(this.transaction).patchAndFetchById(this.id, { status })
     });
   }
 
   patch(data, opts) {
-    return Case.query().findById(this.id)
+    return Case.query(this.transaction).findById(this.id)
       .then(result => {
         return this.update({ ...result.data, ...data }, opts);
       });
@@ -64,12 +67,13 @@ class Case {
         user,
         payload
       },
-      handler: () => Case.query().patchAndFetchById(this.id, { data })
+      transaction: this.transaction,
+      handler: () => Case.query(this.transaction).patchAndFetchById(this.id, { data })
     });
   }
 
-  static query() {
-    return this.Model.query();
+  static query(transaction) {
+    return this.Model.query(transaction);
   }
 
   static db(db) {
@@ -132,7 +136,7 @@ class Case {
     return query;
   }
 
-  static create(data, { user, payload }) {
+  static create(data, { user, payload, transaction }) {
     const model = {
       id: uuid(),
       status: 'new',
@@ -146,12 +150,13 @@ class Case {
         data,
         payload
       },
-      handler: () => this.Model.query().insert(model)
+      transaction,
+      handler: () => this.Model.query(transaction).insert(model)
     });
   }
 
-  static find(id) {
-    return this.Model.query().findById(id)
+  static find(id, transaction) {
+    return this.Model.query(transaction).findById(id)
       .eager('[activityLog]')
       .modifyEager('[activityLog]', builder => {
         builder.orderBy('createdAt', 'DESC');
@@ -160,7 +165,7 @@ class Case {
         if (!model) {
           throw new NotFoundError();
         }
-        return new Case(model);
+        return new Case(model, transaction);
       });
   }
 
@@ -194,6 +199,7 @@ class Case {
         comment,
         payload
       },
+      transaction: this.transaction,
       handler: () => Promise.resolve()
     });
   }
@@ -217,6 +223,7 @@ class Case {
         comment,
         payload
       },
+      transaction: this.transaction,
       handler: () => Promise.resolve()
     });
   }
@@ -233,6 +240,7 @@ class Case {
         id,
         user
       },
+      transaction: this.transaction,
       handler: () => Promise.resolve()
     });
   }

--- a/lib/models/task.js
+++ b/lib/models/task.js
@@ -4,7 +4,7 @@ const { NotFoundError, InvalidRequestError, UnauthorisedError } = require('../er
 const { forOwn } = require('lodash');
 const normaliseComments = require('../activitylog/normalise-comments');
 
-class Case {
+class Task {
 
   constructor(model = {}, transaction) {
     this.id = model.id;
@@ -37,7 +37,7 @@ class Case {
       throw new InvalidRequestError({ status: 'invalid' });
     }
 
-    return Case.hooks.invoke({
+    return Task.hooks.invoke({
       event: `status:${previous}:${status}`,
       id: this.id,
       meta: {
@@ -47,19 +47,19 @@ class Case {
         payload
       },
       transaction: this.transaction,
-      handler: () => Case.query(this.transaction).patchAndFetchById(this.id, { status })
+      handler: () => Task.query(this.transaction).patchAndFetchById(this.id, { status })
     });
   }
 
   patch(data, opts) {
-    return Case.query(this.transaction).findById(this.id)
+    return Task.query(this.transaction).findById(this.id)
       .then(result => {
         return this.update({ ...result.data, ...data }, opts);
       });
   }
 
   update(data, { user, payload }) {
-    return Case.hooks.invoke({
+    return Task.hooks.invoke({
       event: 'update',
       id: this.id,
       meta: {
@@ -68,7 +68,7 @@ class Case {
         payload
       },
       transaction: this.transaction,
-      handler: () => Case.query(this.transaction).patchAndFetchById(this.id, { data })
+      handler: () => Task.query(this.transaction).patchAndFetchById(this.id, { data })
     });
   }
 
@@ -142,7 +142,7 @@ class Case {
       status: 'new',
       data
     };
-    return Case.hooks.invoke({
+    return Task.hooks.invoke({
       event: 'create',
       id: model.id,
       meta: {
@@ -165,7 +165,7 @@ class Case {
         if (!model) {
           throw new NotFoundError();
         }
-        return new Case(model, transaction);
+        return new Task(model, transaction);
       });
   }
 
@@ -191,7 +191,7 @@ class Case {
   }
 
   comment(comment, { user, payload }) {
-    return Case.hooks.invoke({
+    return Task.hooks.invoke({
       event: 'comment',
       id: this.id,
       meta: {
@@ -214,7 +214,7 @@ class Case {
       throw new UnauthorisedError('only comment authors may update a comment');
     }
 
-    return Case.hooks.invoke({
+    return Task.hooks.invoke({
       event: 'update-comment',
       id: this.id,
       meta: {
@@ -233,7 +233,7 @@ class Case {
       throw new UnauthorisedError('only comment authors may delete a comment');
     }
 
-    return Case.hooks.invoke({
+    return Task.hooks.invoke({
       event: 'delete-comment',
       id: this.id,
       meta: {
@@ -246,4 +246,4 @@ class Case {
   }
 }
 
-module.exports = Case;
+module.exports = Task;

--- a/lib/router/index.js
+++ b/lib/router/index.js
@@ -3,11 +3,11 @@ const taskRouter = require('./task');
 const Task = require('../models/task');
 const tasksRouter = require('./tasks');
 
-module.exports = ({ hooks, responder }) => {
+module.exports = () => {
   const router = Router();
 
   router.param('taskId', (req, res, next, taskId) => {
-    Task.find(taskId)
+    Task.find(taskId, req.transaction)
       .then(model => {
         // we don't want the full Task model when fetching, just the values
         req.task = req.method === 'GET' ? model.toJSON() : model;
@@ -16,23 +16,17 @@ module.exports = ({ hooks, responder }) => {
       .catch(next);
   });
 
-  router.use((req, res, next) => {
-    const send = responder(req, res);
-    res.respondWith = (data, meta) => send(data, meta);
-    next();
-  });
-
   router.get('/', tasksRouter());
 
-  router.use('/:taskId', taskRouter({ hooks }));
+  router.use('/:taskId', taskRouter());
 
   router.post('/', (req, res, next) => {
     return Promise.resolve()
       .then(() => {
-        return Task.create(req.body, { hooks, user: req.user, payload: req.body });
+        return Task.create(req.body, { user: req.user, payload: req.body, transaction: req.transaction });
       })
       .then(result => {
-        return Task.find(result.id);
+        return Task.find(result.id, req.transaction);
       })
       .then(data => {
         return res.respondWith(data);

--- a/lib/router/task.js
+++ b/lib/router/task.js
@@ -2,7 +2,7 @@ const { Router } = require('express');
 const { merge } = require('lodash');
 const Task = require('../models/task');
 
-module.exports = ({ hooks }) => {
+module.exports = () => {
 
   const router = Router();
   router.get('/', (req, res, next) => {
@@ -17,10 +17,10 @@ module.exports = ({ hooks }) => {
       .then(result => {
         // merge the data in the payload into the data field of the task
         const data = merge({}, result.data, req.body.data);
-        return req.task.update(data, { hooks, user: req.user, payload: req.body });
+        return req.task.update(data, { user: req.user, payload: req.body });
       })
       .then(() => {
-        return Task.find(req.task.id);
+        return Task.find(req.task.id, req.transaction);
       })
       .then(result => {
         return res.respondWith(result);
@@ -31,10 +31,10 @@ module.exports = ({ hooks }) => {
   router.put('/status', (req, res, next) => {
     return Promise.resolve()
       .then(() => {
-        return req.task.status(req.body.status, { hooks, user: req.user, payload: req.body });
+        return req.task.status(req.body.status, { user: req.user, payload: req.body });
       })
       .then(() => {
-        return Task.find(req.task.id);
+        return Task.find(req.task.id, req.transaction);
       })
       .then(result => {
         return res.respondWith(result);
@@ -45,10 +45,10 @@ module.exports = ({ hooks }) => {
   router.post('/comment(s)?', (req, res, next) => {
     return Promise.resolve()
       .then(() => {
-        return req.task.comment(req.body.comment, { hooks, user: req.user, payload: req.body });
+        return req.task.comment(req.body.comment, { user: req.user, payload: req.body });
       })
       .then(() => {
-        return Task.find(req.task.id);
+        return Task.find(req.task.id, req.transaction);
       })
       .then(result => {
         return res.respondWith(result);
@@ -59,9 +59,9 @@ module.exports = ({ hooks }) => {
   router.put('/comment/:id', (req, res, next) => {
     return Promise.resolve()
       .then(() => {
-        return req.task.updateComment(req.params.id, req.body.comment, { hooks, user: req.user, payload: req.body });
+        return req.task.updateComment(req.params.id, req.body.comment, { user: req.user, payload: req.body });
       })
-      .then(() => Task.find(req.task.id))
+      .then(() => Task.find(req.task.id, req.transaction))
       .then(result => res.respondWith(result))
       .catch(next);
   });
@@ -69,9 +69,9 @@ module.exports = ({ hooks }) => {
   router.delete('/comment/:id', (req, res, next) => {
     return Promise.resolve()
       .then(() => {
-        return req.task.deleteComment(req.params.id, { hooks, user: req.user });
+        return req.task.deleteComment(req.params.id, { user: req.user });
       })
-      .then(() => Task.find(req.task.id))
+      .then(() => Task.find(req.task.id, req.transaction))
       .then(result => res.respondWith(result))
       .catch(next);
   });

--- a/test/integration/specs/create.js
+++ b/test/integration/specs/create.js
@@ -86,6 +86,27 @@ describe('POST /', () => {
       });
   });
 
+  it('will not insert a record if the `create` hook fails', () => {
+    const stub = sinon.stub().rejects(new Error('Test'));
+    this.flow.hook('create', stub);
+
+    return Promise.resolve()
+      .then(() => {
+        return request(this.app)
+          .post('/')
+          .set('Content-type', 'application/json')
+          .send({ test: 'data' })
+          .expect(500);
+      })
+      .then(() => {
+        return request(this.app)
+          .get('/')
+          .expect(response => {
+            assert.deepEqual(response.body.data, [], 'No records are returned from lookup');
+          });
+      });
+  });
+
   it('will not call `create` hooks if the `pre-create` hook fails', () => {
     const pre = sinon.stub().rejects(new Error('Test'));
     const post = sinon.stub().resolves();

--- a/test/integration/specs/task.js
+++ b/test/integration/specs/task.js
@@ -345,7 +345,7 @@ describe('/:task', () => {
             .expect(200)
             .expect(response => {
               assert.equal(response.body.data.status, 'new', 'The status should still be "new"');
-              assert.equal(response.body.data.activityLog.length, 1, 'No new acticity should have been added');
+              assert.equal(response.body.data.activityLog.length, 1, 'No new activity should have been added');
             });
         });
     });
@@ -366,7 +366,7 @@ describe('/:task', () => {
             .expect(200)
             .expect(response => {
               assert.equal(response.body.data.status, 'new', 'The status should still be "new"');
-              assert.equal(response.body.data.activityLog.length, 1, 'No new acticity should have been added');
+              assert.equal(response.body.data.activityLog.length, 1, 'No new activity should have been added');
             });
         });
     });

--- a/test/integration/specs/task.js
+++ b/test/integration/specs/task.js
@@ -330,6 +330,47 @@ describe('/:task', () => {
         });
     });
 
+    it('rolls back status change if hook fails', () => {
+      const payload = { status: 'updated', meta: { comment: 'some reason' } };
+      const stub = sinon.stub().rejects(new Error('test'));
+      this.flow.hook('status:*:*', stub);
+      return request(this.app)
+        .put(`/${id}/status`)
+        .set('Content-type', 'application/json')
+        .send(payload)
+        .expect(500)
+        .then(() => {
+          return request(this.app)
+            .get(`/${id}`)
+            .expect(200)
+            .expect(response => {
+              assert.equal(response.body.data.status, 'new', 'The status should still be "new"');
+              assert.equal(response.body.data.activityLog.length, 1, 'No new acticity should have been added');
+            });
+        });
+    });
+
+    it('rolls back status change if a secondary hook fails', () => {
+      const payload = { status: 'first', meta: { comment: 'some reason' } };
+      const stub = sinon.stub().rejects(new Error('test'));
+      this.flow.hook('status:*:first', m => m.setStatus('second'));
+      this.flow.hook('status:*:second', stub);
+      return request(this.app)
+        .put(`/${id}/status`)
+        .set('Content-type', 'application/json')
+        .send(payload)
+        .expect(500)
+        .then(() => {
+          return request(this.app)
+            .get(`/${id}`)
+            .expect(200)
+            .expect(response => {
+              assert.equal(response.body.data.status, 'new', 'The status should still be "new"');
+              assert.equal(response.body.data.activityLog.length, 1, 'No new acticity should have been added');
+            });
+        });
+    });
+
   });
 
   describe('POST /:task/comment', () => {
@@ -348,6 +389,24 @@ describe('/:task', () => {
             .then(log => {
               assert.equal(log.event.meta.comment, comment, 'Comment is stored in the event metadata');
               assert.deepEqual(log.event.meta.payload, payload, 'Payload is stored in the log event');
+            });
+        });
+    });
+
+    it('does not add comment if comment hook fails', () => {
+      const comment = 'testing add another comment';
+      const payload = { comment, meta: { comment, field: 'title' } };
+      const stub = sinon.stub().rejects(new Error('test'));
+      this.flow.hook('comment', stub);
+      return request(this.app)
+        .post(`/${id}/comment`)
+        .set('Content-type', 'application/json')
+        .send(payload)
+        .expect(500)
+        .then(() => {
+          return ActivityLog.query(this.flow.db).findOne({ eventName: 'comment', comment })
+            .then(log => {
+              assert.ok(!log, 'No comment should have been added');
             });
         });
     });


### PR DESCRIPTION
Stop just assuming everything will be ok and moonwalking away from data manipulation.

If a hook fails then rollback any updates made in that request cycle rather than leaving broken data behind.

Note: The event passed into hooks as arguments now has a `transaction` property and a `find` method. If doing db queries inside a hook then either:

a) Use the new event `find(id)` method instead of `Task.find(id)`
b) Pass the event's `transaction` into the query