### PR TITLE
Allow assignment functions to be used in hooks

### DIFF
--- a/lib/hooks/event-wrapper.js
+++ b/lib/hooks/event-wrapper.js
@@ -27,6 +27,7 @@ class EventWrapper {
       .then(model => {
         this.status = model.status;
         this.data = model.data;
+        this.assignedTo = model.assignedTo;
       });
   }
 
@@ -53,6 +54,16 @@ class EventWrapper {
     return Task.find(this.id, this.transaction)
       .then(model => {
         return model.update(data, { ...this.meta });
+      });
+  }
+
+  assign(user) {
+    if (this.isPreCreateHook) {
+      return console.error('WARNING: cannot assign case models in pre-create hooks.');
+    }
+    return Task.find(this.id, this.transaction)
+      .then(model => {
+        return model.assign(user, { ...this.meta });
       });
   }
 


### PR DESCRIPTION
Adds an `assign` method and `assignedTo` property to the event model passed as an argument to hooks.

This means that we can automatically assign and unassign tasks when they move statuses.