### PR TITLE
Make activity log available to hook functions

### DIFF
--- a/lib/hooks/event-wrapper.js
+++ b/lib/hooks/event-wrapper.js
@@ -25,6 +25,7 @@ class EventWrapper {
         return model.toJSON();
       })
       .then(model => {
+        Object.defineProperty(this, 'activityLog', { value: model.activityLog, configurable: true });
         this.status = model.status;
         this.data = model.data;
         this.assignedTo = model.assignedTo;


### PR DESCRIPTION
Adds the activty log to the event model passed to hook functions. This means that hooks can perform actions based on the previous activity recorded on the task.

Use `Object.defineProperty` to assign the activity log to the event model so that the log is non-enumerable by default, and so doesn't get recursively written into the activity log by the activity log hook.