### PR TITLE
Index on case_id fk would help when joining from cases

### DIFF
--- a/migrations/20211126104750_add_index_on_case_id_for_joins.js
+++ b/migrations/20211126104750_add_index_on_case_id_for_joins.js
@@ -1,0 +1,12 @@
+
+exports.up = function(knex) {
+  return knex.schema.table('activity_log', table => {
+    table.index('case_id');
+  });
+};
+
+exports.down = function(knex) {
+  return knex.schema.table('activity_log', table => {
+    table.dropIndex('case_id');
+  });
+};


### PR DESCRIPTION
Postgres does not automatically add indexes on foreign keys, but if joining from cases -> activity log it's useful to have one.