### PR TITLE
[ASL-4304] switch taskflow publishing to internal npm

### DIFF
--- a/.drone-1.0.yml
+++ b/.drone-1.0.yml
@@ -25,20 +25,22 @@ steps:
   - name: audit
     image: node:18
     environment:
-      NPM_AUTH_USERNAME:
-        from_secret: npm_auth_username
-      NPM_AUTH_TOKEN:
-        from_secret: npm_auth_token
+      ART_AUTH_TOKEN:
+        from_secret: art_auth_token
+      GITHUB_AUTH_TOKEN:
+        from_secret: github_token
     commands:
       - npm audit --audit-level=high --production
 
   - name: publish
-    image: plugins/npm
-    settings:
-      token:
-        from_secret: npm_token
-      email:
-        from_secret: npm_email
+    image: node:18
+    environment:
+      ART_AUTH_TOKEN:
+        from_secret: art_auth_token
+      GITHUB_AUTH_TOKEN:
+        from_secret: github_token
+    commands:
+      - npm publish
     when:
       event:
         - tag

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@ukhomeoffice/taskflow",
+  "name": "@ukhomeoffice/asl-taskflow",
   "version": "2.7.0",
   "description": "Proof of concept for workflow task management",
   "main": "index.js",
@@ -42,6 +42,6 @@
     "witch": "^1.0.3"
   },
   "publishConfig": {
-    "access": "public"
-  }
+    "@ukhomeoffice:registry": "https://npm.pkg.github.com"
+  },
 }

--- a/package.json
+++ b/package.json
@@ -43,5 +43,5 @@
   },
   "publishConfig": {
     "@ukhomeoffice:registry": "https://npm.pkg.github.com"
-  },
+  }
 }


### PR DESCRIPTION
this change has come about as a result of introducing an internal @ukhomeoffice scope, probably not realising a public npm scope already existed.

In order not to confuse npm horribly by trying to get it to install the same @ukhomeoffice scope from two separate registries, this commit moves publishing to the internal registry to unblock upstream work.